### PR TITLE
Enable Enter key for guessing

### DIFF
--- a/script.js
+++ b/script.js
@@ -234,6 +234,9 @@ function endGame() {
 
 // Événements
 btn.addEventListener('click', guess);
+input.addEventListener('keyup', (e) => {
+  if (e.key === 'Enter') guess();
+});
 hintBtn.addEventListener('click', () => {
   msg.textContent = `Indice : ${sequence[current].hint}`;
 });


### PR DESCRIPTION
## Summary
- add keyup listener to trigger `guess()` when hitting Enter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883b3bfe4888326aefcd92b499fef8b