### PR TITLE
Adjust hangman failure limit

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ const wordsList = [
 ];
 
 const totalRounds = 3;
-const maxParts    = 6;
+const maxParts    = 9; // allow up to 9 wrong attempts
 const parts       = ["post","beam","rope","head","body","left-arm","right-arm","left-leg","right-leg"];
 
 let sequence = [], found = 0, current = 0, wrong = 0;


### PR DESCRIPTION
## Summary
- allow nine wrong guesses before moving to the next word

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6883b61095148326864bc12c1029da89