### PR TITLE
Implement countdown timer and conditional hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <h1>Jeu du Pendu</h1>
   <div id="status">
     <div id="round">Trouvés : 0</div>
-    <div id="timer">Temps écoulé : <span id="time-left">00:00</span></div>
+    <div id="timer">Temps restant : <span id="time-left">03:00</span></div>
   </div>
   <div id="game-container">
     <svg id="hangman-svg" width="200" height="250">

--- a/script.js
+++ b/script.js
@@ -52,8 +52,9 @@ function startTimer() {
 }
 
 function updateTimer() {
-  const m = String(Math.floor(timeElapsed / 60)).padStart(2,'0');
-  const s = String(timeElapsed % 60).padStart(2,'0');
+  const remaining = gameDuration - timeElapsed;
+  const m = String(Math.floor(remaining / 60)).padStart(2, '0');
+  const s = String(remaining % 60).padStart(2, '0');
   timerEl.textContent = `${m}:${s}`;
 }
 
@@ -65,6 +66,8 @@ function nextWord() {
   msg.textContent = '';
   roundEl.textContent = `Trouvés : ${found}`;
   input.disabled = false; btn.disabled = false;
+  hintBtn.disabled = true;
+  hintBtn.classList.remove('active');
   restart.style.display = 'none';
 }
 
@@ -104,6 +107,10 @@ function guess() {
     if (wrong < maxParts) {
       document.getElementById(parts[wrong]).style.display = 'inline';
       wrong++;
+      if (wrong === 3) {
+        hintBtn.disabled = false;
+        hintBtn.classList.add('active');
+      }
     }
     if (wrong >= maxParts) {
       msg.textContent = `Pendu ! Le mot était : ${currentWord.word}`;

--- a/style.css
+++ b/style.css
@@ -57,3 +57,11 @@ button {
 #hint-btn:hover {
   background-color: #e0a800;
 }
+#hint-btn:disabled {
+  background-color: #ccc;
+  cursor: default;
+}
+#hint-btn.active {
+  background-color: #28a745;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- show remaining time instead of elapsed time
- disable hint button until three mistakes and switch it green when active

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68864b659e048326978fcc7c2bc511e0